### PR TITLE
Updating of serenity core version to rc.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
 }
 
 ext {
-    serenityCoreVersion = "1.1.25-rc.3"
+    serenityCoreVersion = "1.1.25-rc.5"
 
     // Bintray configuration
     bintrayBaseUrl = 'https://api.bintray.com/maven'
@@ -51,6 +51,7 @@ allprojects {
         resolutionStrategy {
             // fail fast on dependency convergence problems
             failOnVersionConflict()
+            force  'commons-collections:commons-collections:3.2.2'
         }
     }
 }
@@ -252,6 +253,11 @@ subprojects {
                 exclude group: "junit"
                 exclude group:"org.codehaus.groovy", module: "groovy-all"
             }
+        }
+
+        task copyDeps(type: Copy) {
+            from configurations.runtime + configurations.testCompile
+            into project.projectDir.path + "/lib"
         }
     }
 }


### PR DESCRIPTION
#### Summary of this PR
Updating dependency for using last serenity core
#### Intended effect
Will be used commons-collections:commons-collections:3.2.2 instead of 3.2.1 as in selenium 2.50.1. 
#### How should this be manually tested?
Project with last serenity core should be build.
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A