### PR TITLE
Fixed nullpointer exception, if description is empty

### DIFF
--- a/serenity-jira-requirements-provider/src/main/java/net/serenitybdd/plugins/jira/requirements/JIRARequirementsProvider.java
+++ b/serenity-jira-requirements-provider/src/main/java/net/serenitybdd/plugins/jira/requirements/JIRARequirementsProvider.java
@@ -18,6 +18,7 @@ import net.thucydides.core.model.TestTag;
 import net.thucydides.core.requirements.RequirementsTagProvider;
 import net.thucydides.core.requirements.model.Requirement;
 import net.thucydides.core.util.EnvironmentVariables;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
@@ -177,7 +178,7 @@ public class JIRARequirementsProvider implements RequirementsTagProvider {
     private String narativeTextFrom(IssueSummary issue) {
         Optional<String> customFieldName = Optional.fromNullable(environmentVariables.getProperty(JIRA_CUSTOM_NARRATIVE_FIELD.getName()));
         if (customFieldName.isPresent()) {
-            return customFieldNameFor(issue, customFieldName.get()).or(issue.getRendered().getDescription());
+            return customFieldNameFor(issue, customFieldName.get()).or(ObjectUtils.firstNonNull(issue.getRendered().getDescription(), ""));
         } else {
             return issue.getRendered().getDescription();
         }

--- a/serenity-jira-requirements-provider/src/main/java/net/serenitybdd/plugins/jira/requirements/RequirementsAdaptor.java
+++ b/serenity-jira-requirements-provider/src/main/java/net/serenitybdd/plugins/jira/requirements/RequirementsAdaptor.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import net.serenitybdd.plugins.jira.domain.IssueSummary;
 import net.thucydides.core.requirements.model.Requirement;
 import net.thucydides.core.util.EnvironmentVariables;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -41,7 +42,7 @@ public class RequirementsAdaptor {
     private String narativeTextFrom(IssueSummary issue) {
         Optional<String> customFieldName = Optional.fromNullable(environmentVariables.getProperty(JIRA_CUSTOM_NARRATIVE_FIELD.getName()));
         if (customFieldName.isPresent()) {
-            return customFieldNameFor(issue, customFieldName.get()).or(issue.getRendered().getDescription());
+            return customFieldNameFor(issue, customFieldName.get()).or(ObjectUtils.firstNonNull(issue.getRendered().getDescription(), ""));
         } else {
             return issue.getRendered().getDescription();
         }


### PR DESCRIPTION
#### Summary of this PR
Fixed nullpointer exception, if description is empty
#### Intended effect
If in jira there is no field with name description - there should't be any nullpointers
#### How should this be manually tested?
For example used 
Narrative:
As a test developer
I want to use a field "Beschreibung" in the stories in JIRA
In order to describe my story there.
Scenario:
Given there is an field "Beschreibung" configured for stories in JIRA but no field named "Description"
And I set jira.custom.narrative.field=Beschreibung 

for this situation all should work without nullpointers
#### Side effects
N/A 
#### Documentation
N/A
#### Relevant tickets
#33 
#### Screenshots (if appropriate)
N/A