### PR TITLE
fix: Added null check for allowedValues

### DIFF
--- a/serenity-jira-plugin/src/main/java/net/serenitybdd/plugins/jira/client/JerseyJiraClient.java
+++ b/serenity-jira-plugin/src/main/java/net/serenitybdd/plugins/jira/client/JerseyJiraClient.java
@@ -642,7 +642,8 @@ public class JerseyJiraClient {
                     while(fieldKeys.hasNext()) {
                         String entryFieldName = fieldKeys.next().getKey();
                         JsonObject entry = fields.getAsJsonObject(entryFieldName);
-                        if (entry.getAsJsonPrimitive("name").getAsString().equalsIgnoreCase(fieldName)) {
+                        if (entry.getAsJsonPrimitive("name").getAsString().equalsIgnoreCase(fieldName) 
+                            && entry.getAsJsonArray("allowedValues")!=null) {
                             result.addAll(convertToCascadingSelectOptions(entry.getAsJsonArray("allowedValues")));
                         }
                     }


### PR DESCRIPTION
In our project, we had custom field - customfield_15844 which had same name as "Requirements" but it dosn't have any "allowedValues" object (JSON from JIRA provided below) . So, when aggregation step starts (serenity-maven-plugin:1.4.1-rc.7:aggregate - serenity-reports) it fails with null pointer exception as given below. Adding null value check before invoking the method solves the issue.

Caused by: org.apache.maven.plugin.PluginExecutionException: Execution serenity-reports of goal net.serenity-bdd.maven.plugins:serenity-maven-plugin:1.4.1-rc.7:aggregate failed.
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:145)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	... 20 more
Caused by: java.lang.NullPointerException
	at net.serenitybdd.plugins.jira.client.JerseyJiraClient.convertToCascadingSelectOptions(JerseyJiraClient.java:678)
	at net.serenitybdd.plugins.jira.client.JerseyJiraClient.convertToCascadingSelectOptions(JerseyJiraClient.java:672)
	at net.serenitybdd.plugins.jira.client.JerseyJiraClient.findOptionsForCascadingSelect(JerseyJiraClient.java:640)
	at net.serenitybdd.plugins.jira.requirements.JIRACustomFieldsRequirementsProvider.getRequirements(JIRACustomFieldsRequirementsProvider.java:116)
	at net.thucydides.core.requirements.reports.MultipleSourceRequirmentsOutcomeFactory.buildRequirementsOutcomesFrom(MultipleSourceRequirmentsOutcomeFactory.java:51)
	at net.thucydides.core.reports.html.HtmlAggregateStoryReporter.generateReportsForTestResultsIn(HtmlAggregateStoryReporter.java:154)
	at net.thucydides.core.reports.html.HtmlAggregateStoryReporter.generateReportsForTestResultsFrom(HtmlAggregateStoryReporter.java:136)
	at net.serenitybdd.maven.plugins.SerenityAggregatorMojo.generateHtmlStoryReports(SerenityAggregatorMojo.java:234)
	at net.serenitybdd.maven.plugins.SerenityAggregatorMojo.execute(SerenityAggregatorMojo.java:177)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	... 21 more


JSON for fields object from JIRA:

"customfield_15844": {
    "required": false,
    "schema": {
      "type": "string",
      "custom": "com.atlassian.jira.plugin.system.customfieldtypes:textfield",
      "customId": 15844
    },
    "name": "Requirements",
    "hasDefaultValue": false,
    "operations": [
      "set"
    ]
  }